### PR TITLE
Enable building shared libXNVCtrl.so library

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -79,6 +79,13 @@ endif
 
 XNVCTRL_DIR             ?= libXNVCtrl
 XNVCTRL_ARCHIVE         ?= $(XNVCTRL_DIR)/libXNVCtrl.a
+XNVCTRL_SHARED          ?= $(XNVCTRL_DIR)/libXNVCtrl.so.0
+
+ifeq ($(XNVCTRL_LIB_STATIC),0)
+  XNVCTRL_LIB           ?= $(XNVCTRL_SHARED)
+endif
+XNVCTRL_LIB             ?= $(XNVCTRL_ARCHIVE)
+
 XCONFIG_PARSER_DIR      ?= XF86Config-parser
 COMMON_UTILS_DIR        ?= common-utils
 COMMON_UNIX_DIR         ?= common-unix
@@ -179,9 +186,12 @@ NVIDIA_SETTINGS_install: $(NVIDIA_SETTINGS)
 	$(MKDIR) $(BINDIR)
 	$(INSTALL) $(INSTALL_BIN_ARGS) $< $(BINDIR)/$(notdir $<)
 
-$(NVIDIA_SETTINGS): $(OBJS) $(XNVCTRL_ARCHIVE)
+$(XNVCTRL_ARCHIVE) $(XNVCTRL_SHARED):
+	$(MAKE) -C $(XNVCTRL_DIR)
+
+$(NVIDIA_SETTINGS): $(OBJS) $(XNVCTRL_LIB)
 	$(call quiet_cmd,LINK) $(CFLAGS) $(LDFLAGS) $(BIN_LDFLAGS) -o $@ $(OBJS) \
-	    $(XNVCTRL_ARCHIVE) $(LIBS)
+	    $(XNVCTRL_LIB) $(LIBS)
 	$(call quiet_cmd,STRIP_CMD) $@
 
 # define the rule to build each object file
@@ -191,6 +201,7 @@ $(foreach src,$(SRC),$(eval $(call DEFINE_OBJECT_RULE,TARGET,$(src))))
 $(eval $(call DEFINE_STAMP_C_RULE, $(OBJS),$(NVIDIA_SETTINGS_PROGRAM_NAME)))
 
 clean clobber:
+	$(MAKE) -C $(XNVCTRL_DIR) clean
 	rm -rf $(NVIDIA_SETTINGS) *~ $(STAMP_C) \
 		$(OUTPUTDIR)/*.o $(OUTPUTDIR)/*.d
 

--- a/src/libXNVCtrl/Makefile
+++ b/src/libXNVCtrl/Makefile
@@ -19,15 +19,31 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+VERSION_MK := $(wildcard $(OUTPUTDIR)/version.mk version.mk)
+include $(VERSION_MK)
+
+ifndef NVIDIA_VERSION
+$(error NVIDIA_VERSION undefined)
+endif
+
 RANLIB ?= ranlib
 CFLAGS += -fPIC
 
+all: libXNVCtrl.a libXNVCtrl.so
+
 libXNVCtrl.a : libXNVCtrl.a(NVCtrl.o)
 	$(RANLIB) $@
+
+libXNVCtrl.so: NVCtrl.o
+	$(RM) $@ $@.*
+	$(CC) -shared -Wl,-soname=$@.0 -o $@.$(NVIDIA_VERSION) $(LDFLAGS) $^ -lXext -lX11
+	ln -s $@.$(NVIDIA_VERSION) $@.0
+	ln -s $@.0 $@
 
 NVCtrl.o : NVCtrl.h nv_control.h NVCtrlLib.h
 .INTERMEDIATE: NVCtrl.o
 
 clean ::
 	rm -f libXNVCtrl.a *.o
+	rm -f libXNVCtrl.so libXNVCtrl.so.*
 .PHONY: clean


### PR DESCRIPTION
Enable building shared libXNVCtrl.so library by passing XNVCTRL_LIB_STATIC=0 to the make command.

Would be very nice to have for distributions.

Thanks,
--Simone
