### PR TITLE
Add support for SOURCE_DATE_EPOCH to allow reproducible builds

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -104,12 +104,19 @@ $(GEN_MANPAGE_OPTS): $(GEN_MANPAGE_OPTS_OBJS)
 $(OPTIONS_1_INC): $(GEN_MANPAGE_OPTS)
 	@$< > $@
 
+DATE_FMT = %F
+ifdef SOURCE_DATE_EPOCH
+    BUILD_DATE ?= $(shell $(DATE) -u -d "@$(SOURCE_DATE_EPOCH)" "+$(DATE_FMT)"  2>/dev/null || $$(DATE) -u -r "$(SOURCE_DATE_EPOCH)" "+$(DATE_FMT)" 2>/dev/null || $(DATE) -u "+$(DATE_FMT)")
+else
+    BUILD_DATE ?= $(shell $(DATE) "+$(DATE_FMT)")
+endif
+
 $(MANPAGE_not_gzipped): nvidia-settings.1.m4 $(OPTIONS_1_INC) $(VERSION_MK)
 	$(call quiet_cmd,M4) \
 	  -D__HEADER__=$(AUTO_TEXT) \
 	  -D__BUILD_OS__=$(TARGET_OS) \
 	  -D__VERSION__=$(NVIDIA_VERSION) \
-	  -D__DATE__="`$(DATE) +%F`" \
+	  -D__DATE__="$(BUILD_DATE)" \
 	  -I $(OUTPUTDIR) \
 	  $< > $@
 

--- a/src/libXNVCtrl/utils.mk
+++ b/src/libXNVCtrl/utils.mk
@@ -439,6 +439,12 @@ endef
 
 STAMP_C = $(OUTPUTDIR)/g_stamp.c
 
+ifdef SOURCE_DATE_EPOCH
+    BUILD_DATE ?= $(shell $(DATE) -u -d "@$(SOURCE_DATE_EPOCH)" 2>/dev/null || $(DATE) -u -r "$(SOURCE_DATE_EPOCH)" 2>/dev/null || $(DATE) -u)
+else
+    BUILD_DATE ?= $(shell $(DATE))
+endif
+
 define DEFINE_STAMP_C_RULE
 
   $$(STAMP_C): $$(filter-out \
@@ -450,7 +456,7 @@ define DEFINE_STAMP_C_RULE
 	@ $$(PRINTF) "%s"   "version $$(NVIDIA_VERSION)  "              >> $$@
 	@ $$(PRINTF) "%s"   "($$(shell $$(WHOAMI))"                     >> $$@
 	@ $$(PRINTF) "%s"   "@$$(shell $$(HOSTNAME_CMD)))  "            >> $$@
-	@ $$(PRINTF) "%s\n" "$$(shell $(DATE))\";"                      >> $$@
+	@ $$(PRINTF) "%s\n" "$$(BUILD_DATE)\";"                         >> $$@
 	@ $$(PRINTF) "%s\n" "const char *pNV_ID = NV_ID + 11;"          >> $$@
 
 endef

--- a/src/libXNVCtrl/utils.mk
+++ b/src/libXNVCtrl/utils.mk
@@ -441,8 +441,12 @@ STAMP_C = $(OUTPUTDIR)/g_stamp.c
 
 ifdef SOURCE_DATE_EPOCH
     BUILD_DATE ?= $(shell $(DATE) -u -d "@$(SOURCE_DATE_EPOCH)" 2>/dev/null || $(DATE) -u -r "$(SOURCE_DATE_EPOCH)" 2>/dev/null || $(DATE) -u)
+    BUILD_USER ?= build-user
+    BUILD_HOST ?= build-machine
 else
     BUILD_DATE ?= $(shell $(DATE))
+    BUILD_USER ?= $(shell $(WHOAMI))
+    BUILD_HOST ?= $(shell $(HOSTNAME_CMD))
 endif
 
 define DEFINE_STAMP_C_RULE
@@ -454,8 +458,8 @@ define DEFINE_STAMP_C_RULE
 	@ $$(PRINTF) "%s"   "const char NV_ID[] = \"nvidia id: "        >> $$@
 	@ $$(PRINTF) "%s"   "$(2):  "                                   >> $$@
 	@ $$(PRINTF) "%s"   "version $$(NVIDIA_VERSION)  "              >> $$@
-	@ $$(PRINTF) "%s"   "($$(shell $$(WHOAMI))"                     >> $$@
-	@ $$(PRINTF) "%s"   "@$$(shell $$(HOSTNAME_CMD)))  "            >> $$@
+	@ $$(PRINTF) "%s"   "($$(BUILD_USER)"                           >> $$@
+	@ $$(PRINTF) "%s"   "@$$(BUILD_HOST))  "                        >> $$@
 	@ $$(PRINTF) "%s\n" "$$(BUILD_DATE)\";"                         >> $$@
 	@ $$(PRINTF) "%s\n" "const char *pNV_ID = NV_ID + 11;"          >> $$@
 

--- a/utils.mk
+++ b/utils.mk
@@ -439,6 +439,12 @@ endef
 
 STAMP_C = $(OUTPUTDIR)/g_stamp.c
 
+ifdef SOURCE_DATE_EPOCH
+    BUILD_DATE ?= $(shell $(DATE) -u -d "@$(SOURCE_DATE_EPOCH)" 2>/dev/null || $(DATE) -u -r "$(SOURCE_DATE_EPOCH)" 2>/dev/null || $(DATE) -u)
+else
+    BUILD_DATE ?= $(shell $(DATE))
+endif
+
 define DEFINE_STAMP_C_RULE
 
   $$(STAMP_C): $$(filter-out \
@@ -450,7 +456,7 @@ define DEFINE_STAMP_C_RULE
 	@ $$(PRINTF) "%s"   "version $$(NVIDIA_VERSION)  "              >> $$@
 	@ $$(PRINTF) "%s"   "($$(shell $$(WHOAMI))"                     >> $$@
 	@ $$(PRINTF) "%s"   "@$$(shell $$(HOSTNAME_CMD)))  "            >> $$@
-	@ $$(PRINTF) "%s\n" "$$(shell $(DATE))\";"                      >> $$@
+	@ $$(PRINTF) "%s\n" "$$(BUILD_DATE)\";"                         >> $$@
 	@ $$(PRINTF) "%s\n" "const char *pNV_ID = NV_ID + 11;"          >> $$@
 
 endef

--- a/utils.mk
+++ b/utils.mk
@@ -441,8 +441,12 @@ STAMP_C = $(OUTPUTDIR)/g_stamp.c
 
 ifdef SOURCE_DATE_EPOCH
     BUILD_DATE ?= $(shell $(DATE) -u -d "@$(SOURCE_DATE_EPOCH)" 2>/dev/null || $(DATE) -u -r "$(SOURCE_DATE_EPOCH)" 2>/dev/null || $(DATE) -u)
+    BUILD_USER ?= build-user
+    BUILD_HOST ?= build-machine
 else
     BUILD_DATE ?= $(shell $(DATE))
+    BUILD_USER ?= $(shell $(WHOAMI))
+    BUILD_HOST ?= $(shell $(HOSTNAME_CMD))
 endif
 
 define DEFINE_STAMP_C_RULE
@@ -454,8 +458,8 @@ define DEFINE_STAMP_C_RULE
 	@ $$(PRINTF) "%s"   "const char NV_ID[] = \"nvidia id: "        >> $$@
 	@ $$(PRINTF) "%s"   "$(2):  "                                   >> $$@
 	@ $$(PRINTF) "%s"   "version $$(NVIDIA_VERSION)  "              >> $$@
-	@ $$(PRINTF) "%s"   "($$(shell $$(WHOAMI))"                     >> $$@
-	@ $$(PRINTF) "%s"   "@$$(shell $$(HOSTNAME_CMD)))  "            >> $$@
+	@ $$(PRINTF) "%s"   "($$(BUILD_USER)"                           >> $$@
+	@ $$(PRINTF) "%s"   "@$$(BUILD_HOST))  "                        >> $$@
 	@ $$(PRINTF) "%s\n" "$$(BUILD_DATE)\";"                         >> $$@
 	@ $$(PRINTF) "%s\n" "const char *pNV_ID = NV_ID + 11;"          >> $$@
 


### PR DESCRIPTION
Hi, I am one of the Debian maintainers of the NVIDIA stack.

In the past couple of years a concerted effort among almost all Linux distros has been striving toward achieving reproducible builds. [1] This involves changes to the toolchain, new tools and CI systems. [2] [3]

These commits add support for SOURCE_DATE_EPOCH [4], which allows users and distribution maintainers to override the timestamps and use the time (UTC) and date of the last change to the source files.

If SOURCE_DATE_EPOCH is set, it also records a fixed user and hostname for the same reasons.
If it is not set then the output is exactly the same as before, for backward compatibility.

[1] https://reproducible-builds.org/
[2] https://reproducible-builds.org/tools/
[3] https://tests.reproducible-builds.org/debian/rb-pkg/unstable/amd64/diffoscope-results/nvidia-settings.html
[4] https://reproducible-builds.org/specs/source-date-epoch/