### PR TITLE
Disable word-wrapping when output is not a terminal

### DIFF
--- a/src/common-utils/msg.c
+++ b/src/common-utils/msg.c
@@ -20,6 +20,8 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
+#define _GNU_SOURCE // needed for fileno
+
 #include <stdio.h>
 #include <stdarg.h>
 #include <stdlib.h>
@@ -88,16 +90,21 @@ void reset_current_terminal_width(unsigned short new_val)
 static void format(FILE *stream, const char *prefix, const char *buf,
                    const int whitespace)
 {
-    int i;
-    TextRows *t;
+    if (isatty(fileno(stream))) {
+        int i;
+        TextRows *t;
 
-    if (!__terminal_width) reset_current_terminal_width(0);
+        if (!__terminal_width) reset_current_terminal_width(0);
 
-    t = nv_format_text_rows(prefix, buf, __terminal_width, whitespace);
+        t = nv_format_text_rows(prefix, buf, __terminal_width, whitespace);
 
-    for (i = 0; i < t->n; i++) fprintf(stream, "%s\n", t->t[i]);
+        for (i = 0; i < t->n; i++) fprintf(stream, "%s\n", t->t[i]);
 
-    nv_free_text_rows(t);
+        nv_free_text_rows(t);
+
+    } else {
+        fprintf(stream, "%s%s\n", prefix ? prefix : "", buf);
+    }
 }
 
 


### PR DESCRIPTION
nvidia-settings seems to always word-wrap the output depending on the current terminal width. It's quite annoying when trying to redirect/pipe nvidia-settings' output for simple record keeping/diffing, simple task automation etc...

This PR shows a quick way to disable word-wrapping of `nv_msg`/`nv_*_msg` functions when the output stream is not a terminal (not `isatty`). 
