### PR TITLE
Do not record the timestamp in gzip file

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -113,4 +113,4 @@ $(MANPAGE_not_gzipped): nvidia-settings.1.m4 $(OPTIONS_1_INC) $(VERSION_MK)
 	  $< > $@
 
 $(MANPAGE_gzipped): $(MANPAGE_not_gzipped)
-	$(GZIP_CMD) -9f < $< > $@
+	$(GZIP_CMD) -9nf < $< > $@


### PR DESCRIPTION
Recording timestamps makes nvidia-settings unreproducible, adding -n as
argument makes gzip not record a timestamp and filename.

Motivation: https://reproducible-builds.org/