### PR TITLE
Update icon path to be relative

### DIFF
--- a/doc/nvidia-settings.desktop
+++ b/doc/nvidia-settings.desktop
@@ -4,7 +4,7 @@ Encoding=UTF-8
 Name=NVIDIA X Server Settings
 Comment=Configure NVIDIA X Server Settings
 Exec=__UTILS_PATH__/nvidia-settings
-Icon=__PIXMAP_PATH__/nvidia-settings.png
+Icon=nvidia-settings
 Categories=__NVIDIA_SETTINGS_DESKTOP_CATEGORIES__
 
 # Translations provided by Sun Microsystems


### PR DESCRIPTION
This means the provided icon PNG is used when the default icon theme (Adwaita or Breeze) is set, but that nvidia-settings icons provided by other themes (such as Papirus) will not be ignored. Previous behaviour: the system icon was always ignored in favour of the package's PNG.