### PR TITLE
Update ctkframelock.c

### DIFF
--- a/src/gtk+-2.x/ctkframelock.c
+++ b/src/gtk+-2.x/ctkframelock.c
@@ -393,8 +393,13 @@ static void framelock_state_received(GObject *object, CtrlEvent *event,
 static void select_widget(GtkWidget *widget, gint state)
 {
     GtkStyle *style = gtk_widget_get_style(widget);
+    GdkColor color;
+    gdk_color_parse ("black", &color);
+
     gtk_widget_modify_fg(widget, GTK_STATE_NORMAL, &(style->text[state]));
     gtk_widget_modify_bg(widget, GTK_STATE_NORMAL, &(style->base[state]));
+    // modify text to be black
+    gtk_widget_modify_fg(widget, GTK_STATE_NORMAL, &color);
 }
 
 


### PR DESCRIPTION
The default text foreground color on the framelock page is white, which is unreadable on the default light grey background.  This changes it to black.
I couldn't find where   &(style->text[state]) was defined -- if that is a better place to make this modification?