### PR TITLE
set supported interface version for `wl_output`

### DIFF
--- a/src/wayland-connector.c
+++ b/src/wayland-connector.c
@@ -94,6 +94,8 @@ static const struct wl_output_listener output_listener = {
     .scale    = output_scale,
 };
 
+#define min_helper(a,b) ((a) > (b) ? (b) : (a))
+
 static void registry_handle_global(void *data_in, struct wl_registry *registry,
                                    uint32_t name, const char *interface,
                                    uint32_t version)
@@ -101,6 +103,7 @@ static void registry_handle_global(void *data_in, struct wl_registry *registry,
     wayland_data *data = (wayland_data*)data_in;
 
     if (strcmp(interface, "wl_output") == 0) {
+        version = min_helper(version, 3);
         wayland_output_info *output;
         output = calloc(1, sizeof(wayland_output_info));
         output->name = name;


### PR DESCRIPTION
Prompted by https://github.com/NixOS/nixpkgs/issues/248119

Recent releases of the wayland protocol updated the `wl_output` protocol to version 4, which added the `wl_output@name` opcode. Since the nvidia wayland connector does not check the version it advertises support but does not register the required handler for that opcode, resulting in an abort when the callback is invoked.

This PR is based on a similar problem reported in https://github.com/swaywm/sway/issues/6717 and clamps the version to the supported range.

Output with `WAYLAND_DEBUG` before change:

> [2919666.139] wl_output@4.geometry(0, 0, 620, 340, 0, "BNQ", "BenQ EL2870U", 0)
> [2919666.141] wl_output@4.mode(3, 3840, 2160, 59996)
> [2919666.142] wl_output@4.scale(2)
> [2919666.143] wl_output@4.name("DP-4")
> fish: Job 1, 'WAYLAND_DEBUG=1 nvidia-settings' terminated by signal SIGABRT (Abort)

Output after change:

> [2872229.841] wl_output@6.geometry(0, 0, 620, 340, 0, "BNQ", "BenQ EL2870U", 0)
> [2872229.846] wl_output@6.mode(3, 3840, 2160, 59996)
> [2872229.848] wl_output@6.scale(2)
> [2872229.849] wl_output@6.done()
