### PR TITLE
Add make target for libXNVCtrl.so

### DIFF
--- a/src/libXNVCtrl/Makefile
+++ b/src/libXNVCtrl/Makefile
@@ -49,9 +49,9 @@ LDFLAGS += $(XNVCTRL_LDFLAGS)
 ##############################################################################
 
 .PHONY: all
-all: $(LIBXNVCTRL)
+all: $(LIBXNVCTRL_STATIC) $(LIBXNVCTRL_SHARED)
 
 .PHONY: clean
 clean:
 	rm -rf $(LIBXNVCTRL) *~ \
-		$(OUTPUTDIR)/*.o $(OUTPUTDIR)/*.d
+		$(OUTPUTDIR)/*.o $(OUTPUTDIR)/*.d $(OUTPUTDIR)/*.so*

--- a/src/libXNVCtrl/xnvctrl.mk
+++ b/src/libXNVCtrl/xnvctrl.mk
@@ -34,7 +34,9 @@ ifndef XNVCTRL_CFLAGS
   XNVCTRL_CFLAGS := $(shell $(PKG_CONFIG) --cflags x11)
 endif
 
-LIBXNVCTRL = $(OUTPUTDIR)/libXNVCtrl.a
+LIBXNVCTRL_STATIC = $(OUTPUTDIR)/libXNVCtrl.a
+
+LIBXNVCTRL_SHARED = $(OUTPUTDIR)/libXNVCtrl.so
 
 LIBXNVCTRL_SRC = $(XNVCTRL_DIR)/NVCtrl.c
 
@@ -42,5 +44,10 @@ LIBXNVCTRL_OBJ = $(call BUILD_OBJECT_LIST,$(LIBXNVCTRL_SRC))
 
 $(eval $(call DEFINE_OBJECT_RULE,TARGET,$(LIBXNVCTRL_SRC)))
 
-$(LIBXNVCTRL) : $(LIBXNVCTRL_OBJ)
+$(LIBXNVCTRL_STATIC) : $(LIBXNVCTRL_OBJ)
 	$(call quiet_cmd,AR) ru $@ $(LIBXNVCTRL_OBJ)
+
+$(LIBXNVCTRL_SHARED): $(LIBXNVCTRL_OBJ)
+	$(CC) -shared -Wl,-soname=$(@F).0 -o $@.0.0.0 $(LDFLAGS) $^ -lXext -lX11
+	ln -s $(@F).0.0.0 $@.0
+	ln -s $(@F).0 $@


### PR DESCRIPTION
Some downstream packages link to this library dynamically, and Linux distributions have had to patch the build to fix dependants.  (Examples: [Arch ticket](https://bugs.archlinux.org/task/76702), [Conky on Manjaro](https://forum.manjaro.org/t/installing-libxnvctrl-525-60-11-2-breaks-dependency-libxnvctrl-so-0-64-required-by-conky/127981).)

Based on a patch by @negativo17 for Fedora:
https://github.com/negativo17/nvidia-settings/blob/master/nvidia-settings-libXNVCtrl.patch