### PR TITLE
Save the settings file under XDG_CONFIG_HOME by default 

### DIFF
--- a/src/command-line.h
+++ b/src/command-line.h
@@ -27,7 +27,6 @@
  */
 struct _CtrlSystemList;
 
-#define DEFAULT_RC_FILE "~/.nvidia-settings-rc"
 #define CONFIG_FILE_OPTION 1
 #define DISPLAY_OPTION 2
 
@@ -47,8 +46,8 @@ typedef struct {
     char *config;        /*
                           * The name of the configuration file (to be
                           * read from, and to be written to); defaults
-                          * to the value of the constant
-                          * DEFAULT_RC_FILE.
+                          * to $XDG_CONFIG_HOME/nvidia/settings-rc or
+                          * ~/.nvidia-settings-rc if the latter exists.
                           */
 
     char **assignments;  /*
@@ -124,7 +123,7 @@ typedef struct {
 
 } Options;
 
-
+const char *locate_default_rc_file(void);
 Options *parse_command_line(int argc, char *argv[],
                             struct _CtrlSystemList *systems);
 

--- a/src/common-utils/common-utils.c
+++ b/src/common-utils/common-utils.c
@@ -297,6 +297,29 @@ void nvfree(void *s)
 /****************************************************************************/
 
 /*
+ * get_user_home() - locate current user's home directory using either
+ * the enrivonment variable or their passwd entry.
+ *
+ * Returns NULL if the home directory cannot be located, otherwise
+ * returns a statically allocated string that is either the value
+ * of the environment variable or the passwd entry.
+ */
+const char *get_user_home()
+{
+    char *home = getenv("HOME");
+    struct passwd *pw;
+
+    if (home) return home;
+
+    /* $HOME isn't set; get the home directory from /etc/passwd */
+
+    pw = getpwuid(getuid());
+    if (pw) return pw->pw_dir;
+
+    return NULL;
+}
+
+/*
  * tilde_expansion() - do tilde expansion on the given path name;
  * based loosely on code snippets found in the comp.unix.programmer
  * FAQ.  The tilde expansion rule is: if a tilde ('~') is alone or
@@ -310,7 +333,7 @@ void nvfree(void *s)
 
 char *tilde_expansion(const char *str)
 {
-    char *prefix = NULL;
+    const char *prefix = NULL;
     const char *replace;
     char *user, *ret;
     struct passwd *pw;
@@ -324,14 +347,7 @@ char *tilde_expansion(const char *str)
 
         /* expand to the current user's home directory */
 
-        prefix = getenv("HOME");
-        if (!prefix) {
-
-            /* $HOME isn't set; get the home directory from /etc/passwd */
-
-            pw = getpwuid(getuid());
-            if (pw) prefix = pw->pw_dir;
-        }
+        prefix = get_user_home();
 
         replace = str + 1;
 

--- a/src/common-utils/common-utils.h
+++ b/src/common-utils/common-utils.h
@@ -64,6 +64,7 @@ char *nvasprintf(const char *fmt, ...) NV_ATTRIBUTE_PRINTF(1, 2);
 void nv_append_sprintf(char **buf, const char *fmt, ...) NV_ATTRIBUTE_PRINTF(2, 3);
 void nvfree(void *s);
 
+const char *get_user_home();
 char *tilde_expansion(const char *str);
 char *nv_prepend_to_string_list(char *list, const char *item, const char *delim);
 

--- a/src/gtk+-2.x/ctkconfig.c
+++ b/src/gtk+-2.x/ctkconfig.c
@@ -24,6 +24,7 @@
  */
 
 #include "ctkconfig.h"
+#include "command-line.h"
 #include "ctkhelp.h"
 #include "ctkwindow.h"
 #include "ctkutils.h"
@@ -305,12 +306,14 @@ static void save_rc_clicked(GtkWidget *widget, gpointer user_data)
     CtkWindow *ctk_window =
         CTK_WINDOW(ctk_get_parent_window(GTK_WIDGET(ctk_config)));
 
+    char *default_rc_file = locate_default_rc_file();
+
     filename =
         ctk_get_filename_from_dialog("Please select a file to save to.",
                                      GTK_WINDOW(ctk_window),
                                      ctk_config->rc_filename ?
                                          ctk_config->rc_filename :
-                                         DEFAULT_RC_FILE);
+                                         default_rc_file);
 
     if (!filename) {
         return;

--- a/src/option-table.h
+++ b/src/option-table.h
@@ -42,7 +42,7 @@ static const NVGetoptOption __options[] = {
     { "config", CONFIG_FILE_OPTION,
       NVGETOPT_STRING_ARGUMENT | NVGETOPT_HELP_ALWAYS, NULL,
       "Use the configuration file &CONFIG& rather than the "
-      "default &" DEFAULT_RC_FILE "&" },
+      "default &$XDG_CONFIG_HOME/nvidia/settings-rc&" },
 
     { "ctrl-display", 'c',
       NVGETOPT_STRING_ARGUMENT | NVGETOPT_HELP_ALWAYS, NULL,


### PR DESCRIPTION
If the settings file does not exist in its legacy location in`~/.nvidia-settings-rc`, store it in`$XDG_CONFIG_HOME/nvidia/settings-rc` instead.

Fixes #30.