### PR TITLE
libXNVCtrlAttributes: relax requirements on getting NV_CTRL_STRING_NV_CONTROL_VERSION

### DIFF
--- a/src/libXNVCtrlAttributes/NvCtrlAttributesNvControl.c
+++ b/src/libXNVCtrlAttributes/NvCtrlAttributesNvControl.c
@@ -493,7 +493,7 @@ NvCtrlNvControlGetStringAttribute(const NvCtrlAttributePrivateHandle *h,
 
     if (attr == NV_CTRL_STRING_NV_CONTROL_VERSION) {
         char str[24];
-        if (h->target_type != X_SCREEN_TARGET) {
+        if (!h->nv) {
             return NvCtrlBadHandle;
         }
         sprintf(str, "%d.%d", h->nv->major_version, h->nv->minor_version);


### PR DESCRIPTION
It was required to get NV_CTRL_STRING_NV_CONTROL_VERSION using X_SCREEN_TARGET handle, however if running on PRIME config where other GPU is the display, we might not be able to get such handle, instead a GPU_TARGET handle is acquired (see `ctk_window_new`).

This relaxes the requirement so that we just check whether the handle has initialized NV-Control attributes (see `NvCtrlAttributeInit`).

Closes: NVIDIA/nvidia-settings#116